### PR TITLE
lectura del dataframe por pedazos y PE

### DIFF
--- a/Anomalias.py
+++ b/Anomalias.py
@@ -14,7 +14,21 @@ import pandas as pd
 
 
 
-os.chdir('/Users/juan/Documents/Gurufocus/Data/csv')
+#os.chdir('/Users/juan/Documents/Gurufocus/Data/csv')
+os.chdir('/home/juang/Documents/Python Scripts/Mercados GURU')
 
+tp = pd.read_csv('output.csv',iterator=True, chunksize=1000)
+Market = pd.concat(tp, ignore_index=True)
+
+
+Market1=Market[0:50000]
+
+percentil=15;
+#price to earnings
+P2E=Market1.loc[Market1['Fiscal Period']=="PE Ratio(TTM)",['Ticker','TTM/current']]
+#price to earnings positivos
+P2Epos=P2E[P2E['TTM/current']>0]
+#p/e bajos - "mejores"
+P2Eupper=P2Epos[P2Epos['TTM/current']<np.percentile(np.array(P2Epos['TTM/current']), percentil)]
 
 Market = pd.read_csv('output.csv')


### PR DESCRIPTION
Parceros cambie la lectura del csv a leerlo por trozos por asunto de memoria
inclui el calculo del P2E pero estoy revisando como hacerlo sobre todo el df porque la memoria no da.